### PR TITLE
Fix codcov coverage

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -56,7 +56,8 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: codecov/codecov-action@v5
         with:
-          name: coverage-test-failures
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: inbo/vespadbImportR
           path: ${{ runner.temp }}/package


### PR DESCRIPTION
I've made a small change to the covr github action yml, to switch to the newest version and to se the repository slug. I found this on stackoverflow as the solution to a similar issue where no test results were making it to codecov. 

Another solution I found was switching to a repository token, but it seems to be working now with the inbo token.